### PR TITLE
Add `mixedContentMode` propType that corresponds to the native module

### DIFF
--- a/AndroidWebView.js
+++ b/AndroidWebView.js
@@ -212,6 +212,11 @@ class AndroidWebView extends Component {
      * @platform android
      */
     allowUniversalAccessFromFileURLs: PropTypes.bool,
+
+    /**
+     * Current behavior of the WebView with regard to loading insecure content from a secure origin.
+     */
+    mixedContentMode: PropTypes.string,
   };
 
   static defaultProps = {


### PR DESCRIPTION
Fix the following error:

<img width="683" alt="2017-05-22 7 17 15" src="https://cloud.githubusercontent.com/assets/8934513/26303643/4893cb6c-3f23-11e7-81ef-a73b55750135.png">