### PR TITLE
Update AndroidWebView.js

### DIFF
--- a/AndroidWebView.js
+++ b/AndroidWebView.js
@@ -105,6 +105,9 @@ class AndroidWebView extends Component {
     contentInset: EdgeInsetsPropType,
     onNavigationStateChange: PropTypes.func,
     onMessage: PropTypes.func,
+    saveFormDataDisabled: PropTypes.bool,
+    thirdPartyCookiesEnabled: PropTypes.bool,
+    mixedContentMode: PropTypes.string,
     onContentSizeChange: PropTypes.func,
     startInLoadingState: PropTypes.bool, // force WebView to show loadingView on first load
     style: View.propTypes.style,


### PR DESCRIPTION
Updated the props type as per the expectation from the native library.

With the updated RN library the current build does not run on device and throws the proptype error. I updated the 3 prop types and it started working.